### PR TITLE
exec issue

### DIFF
--- a/root/usr/bin/rungitea
+++ b/root/usr/bin/rungitea
@@ -13,4 +13,4 @@ export USERNAME=gitea
 export HOME=/home/gitea
 
 # Start Gitea's Web Interface
-exec /home/gitea/gitea web --config=/home/gitea/conf/app.ini
+exec /home/gitea/gitea --config=/home/gitea/conf/app.ini web


### PR DESCRIPTION
A bug requires the web argument to occur after the `--config`. Otherwise the web service is never launched for gitea