### PR TITLE
fix for issue #4 latest image (1.8.0) do not work

### DIFF
--- a/root/usr/bin/rungitea
+++ b/root/usr/bin/rungitea
@@ -12,5 +12,9 @@ export USER=gitea
 export USERNAME=gitea
 export HOME=/home/gitea
 
+# app.ini will be read only config map and latest gitea wants to write a JWT token into it so copy it to new writable location. 
+mkdir -p /home/gitea/writable-config
+cp /home/gitea/conf/app.ini /home/gitea/writable-config/app.ini
+
 # Start Gitea's Web Interface
-exec /home/gitea/gitea web --config=/home/gitea/conf/app.ini
+exec /home/gitea/gitea web --config=/home/gitea/writable-config/app.ini


### PR DESCRIPTION
This is the fix for the app.ini not being writable. 

Until this is merged folks can run my version or 1.9.2 using: 

```sh
oc new-app -f https://raw.githubusercontent.com/wkulhanek/docker-openshift-gitea/master/openshift/gitea-persistent-template.yaml \
  --param=HOSTNAME=${GITEA_URL} \
  --param=GITEA_VERSION=1.9.2 
  --param=GITEA_IMAGE=docker.io/simonmassey/gitea
```
