### PR TITLE
Added tar/gzip/bzip2 to support copying to/from Kubernetes/OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY ./root /
 
 # Update latest packages and install Prerequisites
 RUN microdnf -y update \
-    && microdnf -y install git ca-certificates openssh gettext openssh tzdata \
+    && microdnf -y install git ca-certificates openssh gettext openssh tzdata tar gzip bzip2 \
     && microdnf -y clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
This PR modified the Dockerfile to install DNF packages for tar/gzip/bzip2 so that we can use the `oc cp` or `kubectl cp` commands to copy data to/from the container in Kubernetes/OpenShift.