### PR TITLE
Fix expose-services label and expose non-root port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV REPO_HOME=/gitea-repositories
 LABEL name="Gitea - Git Service" \
       vendor="Gitea" \
       io.k8s.display-name="Gitea - Git Service" \
-      io.openshift.expose-services="3000,gitea" \
+      io.openshift.expose-services="3000/tcp:gitea,2022/tcp:ssh" \
       io.openshift.tags="gitea" \
       build-date="2022-10-17" \
       version=$GITEA_VERSION \
@@ -41,7 +41,7 @@ RUN adduser gitea --home-dir=/home/gitea \
 
 WORKDIR ${APP_HOME}
 VOLUME ${REPO_HOME}
-EXPOSE 22 3000
+EXPOSE 22 2022 3000
 USER 1001
 
 ENTRYPOINT ["/usr/bin/rungitea"]


### PR DESCRIPTION
While the expose-services label is slightly legacy and not documented (that I can find) in the latest versions of OCP, the format for that label can be found here: https://docs.openshift.com/container-platform/3.11/creating_images/metadata.html

I've modified the label to match the target format, and add the non-root SSH port for interpretation in an OpenShift context.

The non-root SSH port at 2022 has been added, while the privileged port of 22 is kept for current backwards compatibility.

The Gitea/SSH daemon still needs to be configured to also listen on port 2022 but this small PR should provide the guided inception of that change in a following PR.